### PR TITLE
Adding relative imports for building file lists

### DIFF
--- a/pyActionRecog/__init__.py
+++ b/pyActionRecog/__init__.py
@@ -1,4 +1,4 @@
-from benchmark_db import *
+from .benchmark_db import *
 
 
 split_parsers = dict()

--- a/pyActionRecog/anet_db.py
+++ b/pyActionRecog/anet_db.py
@@ -1,4 +1,4 @@
-from utils import *
+from .utils import *
 
 
 class Instance(object):

--- a/pyActionRecog/benchmark_db.py
+++ b/pyActionRecog/benchmark_db.py
@@ -1,15 +1,16 @@
+from __future__ import print_function
 import glob
 import fnmatch
 import os
 import random
-from anet_db import ANetDB
+from .anet_db import ANetDB
 
 
 def parse_directory(path, rgb_prefix='img_', flow_x_prefix='flow_x_', flow_y_prefix='flow_y_'):
     """
     Parse directories holding extracted frames from standard benchmarks
     """
-    print 'parse frames under folder {}'.format(path)
+    print('parse frames under folder {}'.format(path))
     frame_folders = glob.glob(os.path.join(path, '*'))
 
     def count_files(directory, prefix_list):
@@ -33,9 +34,9 @@ def parse_directory(path, rgb_prefix='img_', flow_x_prefix='flow_x_', flow_y_pre
             raise ValueError('x and y direction have different number of flow images. video: '+f)
         flow_counts[k] = x_cnt
         if i % 200 == 0:
-            print '{} videos parsed'.format(i)
+            print('{} videos parsed'.format(i))
 
-    print 'frame folder analysis done'
+    print('frame folder analysis done')
     return dir_dict, rgb_counts, flow_counts
 
 

--- a/tools/build_file_list.py
+++ b/tools/build_file_list.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 import os
 import sys
@@ -29,11 +30,11 @@ shuffle = args.shuffle
 
 
 # operation
-print 'processing dataset {}'.format(dataset)
+print('processing dataset {}'.format(dataset))
 split_tp = parse_split_file(dataset)
 f_info = parse_directory(frame_path, rgb_p, flow_x_p, flow_y_p)
 
-print 'writing list files for training/testing'
+print('writing list files for training/testing')
 for i in xrange(max(num_split, len(split_tp))):
     lists = build_split_list(split_tp, f_info, i, shuffle)
     open(os.path.join(out_path, '{}_rgb_train_split_{}.txt'.format(dataset, i+1)), 'w').writelines(lists[0][0])


### PR DESCRIPTION
Running the build_file_list scripts out of the box has compatibility issues. So I have added relative imports which work for Python >= 2.5 (https://docs.python.org/2.5/whatsnew/pep-328.html) 

Added some other compatibility fixes as well and now the scripts run without errors on any Python >= 2.7