### PR TITLE
 For compatibility with opencv3.x issue#276

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -15,7 +15,7 @@ sudo apt-get -qq install libzip-dev
 
 # install common dependencies: OpenCV
 # adpated from OpenCV.sh
-version="2.4.13"
+version="3.4.2"
 
 echo "Building OpenCV" $version
 [[ -d 3rd-party ]] || mkdir 3rd-party/


### PR DESCRIPTION
mentioned in https://github.com/yjxiong/temporal-segment-networks/issues/276
This is a contradiction: The build_all.sh install opencv 2.4.13.6, opencv 2.4.13.6 don't have opencv_contrib, so it surely will not have xfeatures2d. But dense_flow/src/dense_warp_flow_gpu.cpp needs xfeatures2d for compiling, so actually i have to modify the build_all.sh to install opencv3.x, not 2.x and changed the api format from 2.x to 3.x in dense_flow.cpp, accordingly